### PR TITLE
Enabled deterministic builds

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module/ProjectTemplate.csproj
@@ -16,6 +16,7 @@
 		<FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Deterministic>true</Deterministic>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This allows a proper check on comparing the existing dll and the newly built one to skip deploying it if no code has changed.

It also allows adding md5 checksums and so on.

Closes #203