### PR TITLE
Bumps DNN to 9.10.2 and VisualStudio to 2022 (for template project only)

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/IntegrationTests/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/IntegrationTests/ProjectTemplate.csproj
@@ -72,19 +72,19 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="DotNetNuke.Abstractions">
-			<Version>9.10.1</Version>
+			<Version>9.10.2</Version>
 		</PackageReference>
 		<PackageReference Include="DotNetNuke.Core">
-			<Version>9.10.1</Version>
+			<Version>9.10.2</Version>
 		</PackageReference>
 		<PackageReference Include="DotNetNuke.Instrumentation">
-			<Version>9.10.1</Version>
+			<Version>9.10.2</Version>
 		</PackageReference>
 		<PackageReference Include="DotNetNuke.Web">
-			<Version>9.10.1</Version>
+			<Version>9.10.2</Version>
 		</PackageReference>
 		<PackageReference Include="DotNetNuke.WebApi">
-			<Version>9.10.1</Version>
+			<Version>9.10.2</Version>
 		</PackageReference>
 		<PackageReference Include="Effort.EF6">
 			<Version>2.2.15</Version>

--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/UnitTests/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/UnitTests/ProjectTemplate.csproj
@@ -84,19 +84,19 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Abstractions">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Core">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Instrumentation">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Web">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.WebApi">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="Effort.EF6">
       <Version>2.2.15</Version>

--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module/ProjectTemplate.csproj
@@ -119,16 +119,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DotNetNuke.Core">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Instrumentation">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.Web">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="DotNetNuke.WebApi">
-      <Version>9.10.1</Version>
+      <Version>9.10.2</Version>
     </PackageReference>
     <PackageReference Include="EntityFramework">
       <Version>6.4.4</Version>

--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module/manifest.dnn
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module/manifest.dnn
@@ -15,7 +15,7 @@
       <releaseNotes src="ReleaseNotes.html" />
       <azureCompatible>True</azureCompatible>
       <dependencies>
-        <dependency type="coreVersion">09.10.01</dependency>
+        <dependency type="coreVersion">09.10.02</dependency>
       </dependencies>
       <components>
         <component type="Assembly">

--- a/Eraware_Dnn_Templates/Eraware_Dnn_Templates.csproj
+++ b/Eraware_Dnn_Templates/Eraware_Dnn_Templates.csproj
@@ -69,8 +69,13 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.200" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.1.3132" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="VSSDK.TemplateWizardInterface">
       <Version>12.0.4</Version>
     </PackageReference>


### PR DESCRIPTION
This bumps the minimal DNN dependency to v9.10.2 for produced modules

It also bumps the template build tools to Visual Studio 2020 for this project only, this does not affect modules produced from this template