### PR TITLE
Defaults dependabot to monthly

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module/.github/dependabot.yml
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/module.web/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     ignore:
       - dependency-name: "Microsoft.AspNet.WebApi.Client"
       - dependency-name: "Microsoft.AspNet.WebApi.Core"


### PR DESCRIPTION
Dependabot is a useful feature but it can get annoying with too many notifications, this PR makes new projects default to monthly notifications.

Closes #412 