### PR TITLE
Prevent CI from commiting on forks

### DIFF
--- a/Eraware_Dnn_Templates/Properties/AssemblyInfo.cs
+++ b/Eraware_Dnn_Templates/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Eraware_Dnn_Templates/source.extension.vsixmanifest
+++ b/Eraware_Dnn_Templates/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Eraware_Dnn_Templates.e12cae32-028f-413c-85f0-b294a18224bf" Version="1.0.1" Language="en-US" Publisher="Daniel Valadas" />
+        <Identity Id="Eraware_Dnn_Templates.e12cae32-028f-413c-85f0-b294a18224bf" Version="1.0.2" Language="en-US" Publisher="Daniel Valadas" />
         <DisplayName>Eraware_Dnn_Templates</DisplayName>
         <Description xml:space="preserve">Eraware Dnn templates</Description>
         <Tags>dnn</Tags>


### PR DESCRIPTION
This prevents CI runs that commit auto-generated files from running on Forks to prevent forks from becoming out of sync with their upstream branches.

Closes #421