### PR TITLE
Fixed an issue that prevented the list to auto-reload

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module.web/src/components/my-items-list/my-items-list.tsx
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module.web/src/components/my-items-list/my-items-list.tsx
@@ -39,7 +39,10 @@ export class MyItemsList {
   }
 
   componentDidLoad() {
-    this.preload();
+    requestAnimationFrame(() =>
+    {
+      this.preload();
+    })
   }
 
   componentDidUpdate() {
@@ -74,37 +77,39 @@ export class MyItemsList {
   private loadMore() {
     return new Promise<void>((resolve, reject) => {
       if (state.items.length == 0 || state.items.length < state.availableItems) {
-        this.loading = true;
-        this.abortController?.abort();
-        this.abortController = new AbortController();
-        this.itemClient.getItemsPage(
-          state.searchQuery,
-          state.lastFetchedPage + 1,
-          this.pageSize,
-          false,
-          this.abortController.signal)
-          .then(results => {
-            state.items = [...state.items, ...results.items];
-            state.availableItems = results.resultCount;
-            state.lastFetchedPage = results.page;
-            state.totalPages = results.pageCount;
-            this.loading = false;
-            if (state.items.length === results.resultCount) {
-              state.allLoaded = true;
-            }
-            resolve();
-          }, rejectReason => {
-            if (rejectReason instanceof DOMException && rejectReason.code === rejectReason.ABORT_ERR) {
-              reject(() => { });
-              return;
-            }
-            alert(rejectReason);
-            reject(rejectReason);
-          })
-          .catch(rejectReason => {
-            alert(rejectReason);
-            reject(rejectReason);
-          });
+        requestAnimationFrame(() => {
+          this.loading = true;
+          this.abortController?.abort();
+          this.abortController = new AbortController();
+          this.itemClient.getItemsPage(
+            state.searchQuery,
+            state.lastFetchedPage + 1,
+            this.pageSize,
+            false,
+            this.abortController.signal)
+            .then(results => {
+              state.items = [...state.items, ...results.items];
+              state.availableItems = results.resultCount;
+              state.lastFetchedPage = results.page;
+              state.totalPages = results.pageCount;
+              this.loading = false;
+              if (state.items.length === results.resultCount) {
+                state.allLoaded = true;
+              }
+              resolve();
+            }, rejectReason => {
+              if (rejectReason instanceof DOMException && rejectReason.code === rejectReason.ABORT_ERR) {
+                reject(() => { });
+                return;
+              }
+              alert(rejectReason);
+              reject(rejectReason);
+            })
+            .catch(rejectReason => {
+              alert(rejectReason);
+              reject(rejectReason);
+            });
+        });
       }
     });
   }


### PR DESCRIPTION
There was a couple of warning about chaning state during rendering which may cause unwanted behaviours. In this case the list should reload when a item is created or edited and it will a hit-and-miss. After this change, it looks stable.