### PR TITLE
Correct typo in `git` documentation

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/build/docs/articles/git.html
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/build/docs/articles/git.html
@@ -72,7 +72,7 @@
         <p>In a few minutes if you navigate to your repository on Github, you will notice there is a draft release for v0.1.0. It has no release notes yet but it does have the fully packaged module ready for production install.</p>
         <div class="TIP">
             <h5>Tip</h5>
-            <p>This is a draft an the public won't see it as an available release yet. Since this is probably not ready for production, you can delete the release and the tag if you don't want to keep it (and reserve the v0.1.0 version from future use). If you do want to keep it, you can edit it and publish it. Each push to the <code>master</code> branch will trigger a draf release that is non-beta, this is how we will do releases in the future.</p>
+            <p>This is a draft and the public won't see it as an available release yet. Since this is probably not ready for production, you can delete the release and the tag if you don't want to keep it (and reserve the v0.1.0 version from future use). If you do want to keep it, you can edit it and publish it. Each push to the <code>master</code> branch will trigger a draf release that is non-beta, this is how we will do releases in the future.</p>
         </div>
         <h2 id="automatic-versioning">Automatic Versioning</h2>
         <p>The template uses <a href="https://github.com/GitTools/GitVersion">GitVersion</a> and the <a href="https://gitversion.net/docs/git-branching-strategies/gitflow">GitFlow</a> branching strategy in order to manage versions and releases.</p>


### PR DESCRIPTION
Corrected a small typo in the `git` documentation.