### PR TITLE
Removed .Net6 runtime dependency

### DIFF
--- a/Eraware_Dnn_Templates/source.extension.vsixmanifest
+++ b/Eraware_Dnn_Templates/source.extension.vsixmanifest
@@ -38,6 +38,5 @@
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.Net.ComponentGroup.DevelopmentPrerequisites" Version="[17.0.31804.368,18.0)" DisplayName=".NET Framework 4.7.2 development tools" />
-        <Prerequisite Id="Microsoft.NetCore.Component.Runtime.6.0" Version="[17.0.31902.203,18.0)" DisplayName=".NET 6.0 Runtime" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Apparently this is not the SDK and prevents some users from installing/upgrading the extension.
Closes #474