### PR TITLE
Fixed inconsistencies with last EntityFramework update

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/IntegrationTests/App.Config
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/IntegrationTests/App.Config
@@ -14,7 +14,6 @@
   </system.data>
 
   <entityFramework>
-	<defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>
       <provider invariantName="Effort.Provider"
                 type="Effort.Provider.EffortProviderServices, Effort" />

--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/UnitTests/App.config
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/UnitTests/App.config
@@ -14,7 +14,6 @@
   </system.data>
 
   <entityFramework>
-	<defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>
       <provider invariantName="Effort.Provider"
                 type="Effort.Provider.EffortProviderServices, Effort" />

--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module/ProjectTemplate.csproj
@@ -134,7 +134,7 @@
       <Version>9.13.4</Version>
     </PackageReference>
     <PackageReference Include="EntityFramework">
-      <Version>6.4.4</Version>
+      <Version>6.5.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core">
       <Version>5.2.9</Version>


### PR DESCRIPTION
The version was not bumped everywhere and a config was wrong possibly causing flaky tests.