### PR TITLE
Bumped @stencil-community/eslint-plugin to v0.9.0

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module.web/package.json
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module.web/package.json
@@ -28,7 +28,7 @@
     "@dnncommunity/dnn-elements": "^0.23.3",
     "@microsoft/api-documenter": "^7.13.49",
     "@microsoft/api-extractor": "^7.18.9",
-    "@stencil-community/eslint-plugin": "^0.8.0",
+    "@stencil-community/eslint-plugin": "^0.9.0",
     "@stencil/core": "^4.20.0",
     "@stencil/sass": "^3.0.2",
     "@stencil/store": "^2.0.0",

--- a/Eraware_PersonaBarModuleTemplate/module.web/package.json
+++ b/Eraware_PersonaBarModuleTemplate/module.web/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@dnncommunity/dnn-elements": "^0.23.3",
-    "@stencil-community/eslint-plugin": "^0.8.0",
+    "@stencil-community/eslint-plugin": "^0.9.0",
     "@stencil/core": "^4.20.0",
     "@stencil/sass": "^3.0.2",
     "@types/jquery": "^3.5.30",


### PR DESCRIPTION
Bumped @stencil-community/eslint-plugin to v0.9.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `@stencil-community/eslint-plugin` dependency version in both the Stencil Component Starter and Eraware PersonaBar Module Template from `^0.8.0` to `^0.9.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->