### PR TITLE
Added OneOf to the manifests

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module/manifest.dnn
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module/manifest.dnn
@@ -44,6 +44,11 @@
 			  <path>bin</path>
 			  <version>11.9.2</version>
 			</assembly>
+			<assembly>
+			  <name>OneOf.dll</name>
+			  <path>bin</path>
+			  <version>3.0.271</version>
+			</assembly>
           </assemblies>
         </component>
         <component type="Module">

--- a/Eraware_PersonaBarModuleTemplate/module/manifest.dnn
+++ b/Eraware_PersonaBarModuleTemplate/module/manifest.dnn
@@ -35,6 +35,11 @@
 			  <path>bin</path>
 			  <version>11.9.2</version>
 			</assembly>
+			<assembly>
+			  <name>OneOf.dll</name>
+			  <path>bin</path>
+			  <version>3.0.271</version>
+			</assembly>
           </assemblies>
         </component>
         <component type="Cleanup" version="00.01.00" glob="DesktopModules/Admin/Dnn.PersonaBar/Modules/$ext_safeprojectname$/**/*" />


### PR DESCRIPTION
This was missed when OneOf was added in previous version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the `OneOf.dll` library in the module packages, enhancing functionality and dependencies for both the Eraware Dnn Spa and Persona Bar modules.
  
These updates may improve the performance and capabilities of the modules by leveraging the features provided by the newly included library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->