### PR TITLE
Changed CI runner to Ubuntu 22.04

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/build/Build.cs
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/build/Build.cs
@@ -43,7 +43,7 @@ using static Nuke.Common.Tools.ReportGenerator.ReportGeneratorTasks;
 
 [GitHubActions(
     "Build",
-    GitHubActionsImage.UbuntuLatest,
+    GitHubActionsImage.Ubuntu2204,
     ImportSecrets = new[] { nameof(GitHubToken) },
     OnPullRequestBranches = new[] { "develop", "main", "master", "release/*" },
     OnPushBranches = new[] { "main", "master", "develop", "release/*" },

--- a/Eraware_PersonaBarModuleTemplate/_build/Build.cs
+++ b/Eraware_PersonaBarModuleTemplate/_build/Build.cs
@@ -43,7 +43,7 @@ using static Nuke.Common.Tools.ReportGenerator.ReportGeneratorTasks;
 
 [GitHubActions(
     "Build",
-    GitHubActionsImage.UbuntuLatest,
+    GitHubActionsImage.Ubuntu2204,
     ImportSecrets = new[] { nameof(GitHubToken) },
     OnPullRequestBranches = new[] { "develop", "main", "master", "release/*" },
     OnPushBranches = new[] { "main", "master", "develop", "release/*" },


### PR DESCRIPTION
Latest GitHub Ubuntu runner no longer comes with mono preinstalled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Revised the build pipeline configuration to use Ubuntu 22.04, ensuring a consistent and stable environment for continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->