### PR TITLE
Bumped coverlet to v6.0.4

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/IntegrationTests/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/IntegrationTests/ProjectTemplate.csproj
@@ -24,10 +24,10 @@
 		<ProjectReference Include="..\Module.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="6.0.2">
+		<PackageReference Include="coverlet.msbuild" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="DotNetNuke.Abstractions" Version="9.13.4" />

--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/UnitTests/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/UnitTests/ProjectTemplate.csproj
@@ -32,10 +32,10 @@
 		<ProjectReference Include="..\Module.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="6.0.2">
+		<PackageReference Include="coverlet.msbuild" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="DotNetNuke.Abstractions" Version="9.13.4" />

--- a/Eraware_PersonaBarModuleTemplate/UnitTests/ProjectTemplate.csproj
+++ b/Eraware_PersonaBarModuleTemplate/UnitTests/ProjectTemplate.csproj
@@ -32,10 +32,10 @@
 		<ProjectReference Include="..\Module.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="6.0.2">
+		<PackageReference Include="coverlet.msbuild" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="DotNetNuke.Abstractions" Version="9.13.4" />


### PR DESCRIPTION
Bumped coverlet to v6.0.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded internal testing dependencies to their latest stable releases for enhanced test reliability and improved analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->