### PR TITLE
Bumped nuget.commandline to v6.13.2

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/build/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/build/ProjectTemplate.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
 	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.2.0]" />
-	<PackageReference Include="NuGet.CommandLine" Version="6.12.1">
+	<PackageReference Include="NuGet.CommandLine" Version="6.13.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Eraware_PersonaBarModuleTemplate/_build/ProjectTemplate.csproj
+++ b/Eraware_PersonaBarModuleTemplate/_build/ProjectTemplate.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
 	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.2.0]" />
-	<PackageReference Include="NuGet.CommandLine" Version="6.12.1">
+	<PackageReference Include="NuGet.CommandLine" Version="6.13.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Bumped nuget.commandline to v6.13.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the NuGet.CommandLine dependency from version 6.12.1 to 6.13.2 across project templates for improved package management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->