### PR TITLE
Bumped WebApiToOpenApiReflector to v1.3.0

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/build/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/build/ProjectTemplate.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.2.0]" />
+	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.3.0]" />
 	<PackageReference Include="NuGet.CommandLine" Version="6.13.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/PersonaBarModule/_build/ProjectTemplate.csproj
+++ b/PersonaBarModule/_build/ProjectTemplate.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.2.0]" />
+	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.3.0]" />
 	<PackageReference Include="NuGet.CommandLine" Version="6.13.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Bumped WebApiToOpenApiReflector to v1.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the Web API–to–OpenAPI reflection library to v1.3.0 across project templates.
  - Improves compatibility with newer tooling and may enhance accuracy of generated API specifications.
  - Minor stability and performance improvements when producing API documentation.
  - No changes to user-facing features or runtime behavior expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->