### PR TITLE
Bumped nswag to v14.6.1

### DIFF
--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/build/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/build/ProjectTemplate.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSwag.MSBuild" Version="14.2.0" />
+    <PackageReference Include="NSwag.MSBuild" Version="14.6.1" />
     <PackageDownload Include="docfx.console" Version="[2.59.4]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.10.1]" />
     <PackageDownload Include="coverlet.console" Version="[1.7.2]" />

--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module/ProjectTemplate.csproj
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module/ProjectTemplate.csproj
@@ -153,7 +153,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NSwag.Annotations">
-      <Version>14.2.0</Version>
+      <Version>14.6.1</Version>
     </PackageReference>
 	<PackageReference Include="OneOf">
 	  <Version>3.0.271</Version>

--- a/Eraware_Dnn_Spa_Ef_Di_Stencil/module/manifest.dnn
+++ b/Eraware_Dnn_Spa_Ef_Di_Stencil/module/manifest.dnn
@@ -37,7 +37,7 @@
             <assembly>
               <name>NSwag.Annotations.dll</name>
               <path>bin</path>
-              <version>14.2.0</version>
+              <version>14.6.1</version>
             </assembly>
 			<assembly>
 			  <name>FluentValidation.dll</name>

--- a/PersonaBarModule/_build/ProjectTemplate.csproj
+++ b/PersonaBarModule/_build/ProjectTemplate.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSwag.MSBuild" Version="14.2.0" />
+    <PackageReference Include="NSwag.MSBuild" Version="14.6.1" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.10.1]" />
     <PackageDownload Include="coverlet.console" Version="[1.7.2]" />
   </ItemGroup>

--- a/PersonaBarModule/module/ProjectTemplate.csproj
+++ b/PersonaBarModule/module/ProjectTemplate.csproj
@@ -122,7 +122,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NSwag.Annotations">
-      <Version>14.2.0</Version>
+      <Version>14.6.1</Version>
     </PackageReference>
     <PackageReference Include="OneOf">
       <Version>3.0.271</Version>

--- a/PersonaBarModule/module/manifest.dnn
+++ b/PersonaBarModule/module/manifest.dnn
@@ -28,7 +28,7 @@
             <assembly>
               <name>NSwag.Annotations.dll</name>
               <path>bin</path>
-              <version>14.2.0</version>
+              <version>14.6.1</version>
             </assembly>
 			<assembly>
 			  <name>FluentValidation.dll</name>


### PR DESCRIPTION
Bumped nswag to v14.6.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded NSwag dependencies to version 14.6.1 across the solution (including annotations and build tooling).
  - Updates module manifests to reflect the new dependency version.
  - Improves compatibility with newer tooling and enhances stability and maintainability.
  - No changes to UI, features, or workflows; existing functionality remains unchanged.
  - No action required for end-users; standard installations and upgrades continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->