### PR TITLE
Fixed wrong usage of RequiredFrameworkVersion in vstemplate

### DIFF
--- a/Module/IntegrationTests/IntegrationTests.vstemplate
+++ b/Module/IntegrationTests/IntegrationTests.vstemplate
@@ -5,7 +5,7 @@
     <Description>IntegrationTests</Description>
     <ProjectType>CSharp</ProjectType>
     <LanguageTag>csharp</LanguageTag>
-    <RequiredFrameworkVersion>4.8</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.7.2</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>03F8C761-4AC0-47F2-BB17-961796F914CC</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/Module/UnitTests/UnitTests.vstemplate
+++ b/Module/UnitTests/UnitTests.vstemplate
@@ -5,7 +5,7 @@
     <Description>UnitTests</Description>
     <ProjectType>CSharp</ProjectType>
     <LanguageTag>csharp</LanguageTag>
-    <RequiredFrameworkVersion>4.8</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.7.2</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>D3A47104-F56E-40F1-8FDC-C26E061AE87E</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/Module/module/Module.vstemplate
+++ b/Module/module/Module.vstemplate
@@ -6,7 +6,7 @@
     <Icon>module-icon.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <LanguageTag>csharp</LanguageTag>
-    <RequiredFrameworkVersion>4.8</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.7.2</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>cd947cbe-339c-41f7-a789-061d1c59222c</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/Module/root.vstemplate
+++ b/Module/root.vstemplate
@@ -6,7 +6,7 @@
     <Icon>Eraware.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <LanguageTag>csharp</LanguageTag>
-    <RequiredFrameworkVersion>4.8</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.7.2</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>81245841-4dd2-42d2-9c0b-adb41c58ac29</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/PersonaBarModule/UnitTests/UnitTests.vstemplate
+++ b/PersonaBarModule/UnitTests/UnitTests.vstemplate
@@ -5,7 +5,7 @@
     <Description>UnitTests</Description>
     <ProjectType>CSharp</ProjectType>
     <LanguageTag>csharp</LanguageTag>
-    <RequiredFrameworkVersion>4.8</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.7.2</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>e5ad67d7-9b3b-44ce-9baa-e172e87bca15</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/PersonaBarModule/module/Module.vstemplate
+++ b/PersonaBarModule/module/Module.vstemplate
@@ -6,7 +6,7 @@
     <Icon>module-icon.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <LanguageTag>csharp</LanguageTag>
-    <RequiredFrameworkVersion>4.8</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.7.2</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>4af75c04-13e5-4455-97cd-e03dcdcd2618</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/PersonaBarModule/root.vstemplate
+++ b/PersonaBarModule/root.vstemplate
@@ -6,7 +6,7 @@
     <Icon>Eraware.ico</Icon>
     <ProjectType>CSharp</ProjectType>
     <LanguageTag>csharp</LanguageTag>
-    <RequiredFrameworkVersion>4.8</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.7.2</RequiredFrameworkVersion>
     <SortOrder>2000</SortOrder>
     <TemplateID>d3bedb30-a049-48c0-acbd-7374c2ab740a</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>


### PR DESCRIPTION
Apparently 4.8 is not supported in the schema and 4.7.2 is the highest supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Lowered the minimum .NET Framework requirement for all module and Persona Bar templates (including Unit Test and Integration Test templates) from 4.8 to 4.7.2.
  - Improves compatibility with environments targeting .NET Framework 4.7.2, allowing project creation without framework upgrades.
  - No changes to template behavior or structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->