### PR TITLE
Fixed an issue where "Watch" would not work properly and "Deploy" would push all dlls

### DIFF
--- a/PersonaBarModule/_build/Build.cs
+++ b/PersonaBarModule/_build/Build.cs
@@ -282,20 +282,12 @@ class Build : NukeBuild
         .DependsOn(Compile)
         .Executes(() =>
         {
-            var manifest = RootDirectory.GlobFiles("*.dnn").FirstOrDefault();
-            var assemblyFiles = Helpers.GetAssembliesFromManifest(manifest);
-            var files = RootDirectory.GlobFiles("bin/Debug/*.dll", "bin/Debug/*.pdb", "bin/Debug/*.xml");
-            foreach (var file in files)
-            {
-                var fileInfo = new FileInfo(file);
-                if (assemblyFiles.Contains(fileInfo.Name))
-                {
-                    Helpers.CopyFileToDirectoryIfChanged(file, RootDirectory.Parent.Parent / "bin");
-                }
-            }
+            var moduleAssembly = RootDirectory / "bin" / Configuration / $"{moduleName}.dll";
+            moduleAssembly.CopyToDirectory(RootDirectory.Parent.Parent / "bin", ExistsPolicy.FileOverwriteIfNewer);
         });
 
     Target SetRelativeScripts => _ => _
+        .Before(DeployFrontEnd)
         .Executes(() =>
         {
             var views = RootDirectory.GlobFiles("resources/**/*.html");
@@ -309,7 +301,8 @@ class Build : NukeBuild
         });
 
     Target SetLiveServer => _ => _
-        .After(Deploy)
+        .After(DeployBinaries)
+        .Before(DeployFrontEnd)
         .Executes(() =>
         {
             var views = RootDirectory.GlobFiles("resources/*.html");
@@ -329,7 +322,7 @@ class Build : NukeBuild
         {
             var resourcesDirectory = RootDirectory / "resources";
             DeployDirectory.CreateOrCleanDirectory();
-            resourcesDirectory.CopyToDirectory(DeployDirectory, ExistsPolicy.MergeAndOverwrite);
+            resourcesDirectory.Copy(DeployDirectory, ExistsPolicy.MergeAndOverwrite);
         });
 
     Target CopyScripts => _ => _
@@ -531,7 +524,8 @@ class Build : NukeBuild
     /// </summary>
     Target Watch => _ => _
     .DependsOn(SetLiveServer)
-    .DependsOn(Deploy)
+    .DependsOn(DeployBinaries)
+    .DependsOn(DeployFrontEnd)
     .Executes(() =>
     {
         ResetDocs();

--- a/PersonaBarModule/module/ProjectTemplate.csproj
+++ b/PersonaBarModule/module/ProjectTemplate.csproj
@@ -80,6 +80,7 @@
     <Resource Include="ReleaseNotes.html" />
     <Resource Include="build.cmd" />
     <Resource Include="build.sh" />
+	<Resource Include="build.ps1" />
     <Resource Include="global.json" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- The SetLiveServer task was not setting the live-server at the proper timing.
- The DeployBinaries was pushing dlls bypassing DNN dependencies install logic.
- The DeployFrontEnd task was deploying one directory too deep.
- The build.ps1 file was missing from the template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined deployment sequence for binaries and front-end assets to ensure the latest files are used consistently.
  * Optimized copy operations for faster, more reliable updates (single-file DLL copy and merged resource updates).
  * Adjusted live-reload/watch behavior to improve local iteration speed and stability.
  * Included the build script in the package for more predictable setup and deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->