### PR TITLE
Bumped Microsoft.TestPlatform.ObjectModel to v18.0.0

### DIFF
--- a/Module/IntegrationTests/ProjectTemplate.csproj
+++ b/Module/IntegrationTests/ProjectTemplate.csproj
@@ -37,7 +37,7 @@
 		<PackageReference Include="DotNetNuke.WebApi" Version="10.1.1" />
 		<PackageReference Include="Effort.EF6" Version="2.2.17" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />
+		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/Module/UnitTests/ProjectTemplate.csproj
+++ b/Module/UnitTests/ProjectTemplate.csproj
@@ -45,7 +45,7 @@
 		<PackageReference Include="DotNetNuke.WebApi" Version="10.1.1" />
 		<PackageReference Include="Effort.EF6" Version="2.2.17" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.13.0" />
+		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/PersonaBarModule/UnitTests/ProjectTemplate.csproj
+++ b/PersonaBarModule/UnitTests/ProjectTemplate.csproj
@@ -44,7 +44,7 @@
 		<PackageReference Include="DotNetNuke.Web" Version="10.1.1" />
 		<PackageReference Include="DotNetNuke.WebApi" Version="10.1.1" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.13.0" />
+		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
Bumped Microsoft.TestPlatform.ObjectModel to v18.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test platform dependencies to version 18.0.0 across multiple test projects for improved testing infrastructure and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->