### PR TITLE
Bumped Nuget.CommandLine to v6.14.0

### DIFF
--- a/Module/build/ProjectTemplate.csproj
+++ b/Module/build/ProjectTemplate.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
 	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.3.0]" />
-	<PackageReference Include="NuGet.CommandLine" Version="6.13.2">
+	<PackageReference Include="NuGet.CommandLine" Version="6.14.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/PersonaBarModule/_build/ProjectTemplate.csproj
+++ b/PersonaBarModule/_build/ProjectTemplate.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
 	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.3.0]" />
-	<PackageReference Include="NuGet.CommandLine" Version="6.13.2">
+	<PackageReference Include="NuGet.CommandLine" Version="6.14.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Bumped Nuget.CommandLine to v6.14.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NuGet.CommandLine package to version 6.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->