### PR TITLE
Bumped ReportGenerator to v5.4.17

### DIFF
--- a/Module/build/ProjectTemplate.csproj
+++ b/Module/build/ProjectTemplate.csproj
@@ -17,7 +17,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nuke.Common" Version="9.0.4" />
-    <PackageReference Include="ReportGenerator" Version="5.4.4" />
+    <PackageReference Include="ReportGenerator" Version="5.4.17" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/PersonaBarModule/_build/ProjectTemplate.csproj
+++ b/PersonaBarModule/_build/ProjectTemplate.csproj
@@ -17,7 +17,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nuke.Common" Version="9.0.4" />
-    <PackageReference Include="ReportGenerator" Version="5.4.4" />
+    <PackageReference Include="ReportGenerator" Version="5.4.17" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Bumped ReportGenerator to v5.4.17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ReportGenerator dependency to version 5.4.17 across build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->