### PR TITLE
Improved handling of connection string

### DIFF
--- a/Module/build/Build.cs
+++ b/Module/build/Build.cs
@@ -578,28 +578,6 @@ class Build : NukeBuild
             );
     });
 
-
-    Target GenerateAppConfig => _ => _
-    .OnlyWhenDynamic(() => RootDirectory.Parent.ToString().EndsWith("DesktopModules", StringComparison.OrdinalIgnoreCase))
-    .Executes(() =>
-    {
-        var webConfigPath = RootDirectory.Parent.Parent / "web.config";
-        var webConfigDoc = new XmlDocument();
-        webConfigDoc.Load(webConfigPath);
-        var connectionString = webConfigDoc.SelectSingleNode("/configuration/connectionStrings/add[@name='SiteSqlServer']");
-
-        var appConfigPath = RootDirectory / "_build" / "App.config";
-        var appConfig = new XmlDocument();
-        var configurationNode = appConfig.AppendChild(appConfig.CreateElement("configuration"));
-        var connectionStringsNode = configurationNode.AppendChild(appConfig.CreateElement("connectionStrings"));
-        var importedNode = connectionStringsNode.OwnerDocument.ImportNode(connectionString, true);
-        connectionStringsNode.AppendChild(importedNode);
-        appConfig.Save(appConfigPath);
-
-        Serilog.Log.Information("Generated {0} from {1}", appConfigPath, webConfigPath);
-        Serilog.Log.Information("This file is local as it could contain credentials, it should not be committed to the repository.");
-    });
-
     Target SetDependencyVersions => _ => _
     .After(Compile)
     .Executes(() =>
@@ -642,7 +620,6 @@ class Build : NukeBuild
         .DependsOn(SetManifestVersions)
         .DependsOn(Compile)
         .DependsOn(SetRelativeScripts)
-        .DependsOn(GenerateAppConfig)
         .DependsOn(Test)
         .DependsOn(UpdateTokens)
         .DependsOn(Docs)

--- a/Module/module/Data/ModuleDbContext.cs
+++ b/Module/module/Data/ModuleDbContext.cs
@@ -17,6 +17,11 @@ namespace $ext_rootnamespace$.Data
 public class ModuleDbContext : DbContext
     {
         /// <summary>
+        /// Cached connection string, computed lazily and thread-safe.
+        /// </summary>
+        private static readonly Lazy<string> _cachedConnectionString = new Lazy<string>(ComputeConnectionString);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ModuleDbContext"/> class.
         /// </summary>
         public ModuleDbContext()
@@ -38,12 +43,25 @@ public class ModuleDbContext : DbContext
         /// </summary>
         public DbSet<Item> Items { get; set; }
 
+        /// <summary>
+        /// Gets the connection string, using cached value after first call.
+        /// </summary>
+        /// <returns>The connection string.</returns>
         private static string GetConnectionString()
+        {
+            return _cachedConnectionString.Value;
+        }
+
+        /// <summary>
+        /// Computes the connection string by checking runtime context and configuration files.
+        /// This method is called only once per application lifetime.
+        /// </summary>
+        /// <returns>The connection string.</returns>
+        private static string ComputeConnectionString()
         {
             // For runtime
             if (HttpContext.Current != null)
             {
-                Console.WriteLine("HttpContext was not null");
                 return "name=SiteSqlServer";
             }
 

--- a/Module/module/Data/ModuleDbContext.cs
+++ b/Module/module/Data/ModuleDbContext.cs
@@ -8,11 +8,13 @@ namespace $ext_rootnamespace$.Data
     using System.Data.Common;
     using System.Data.Entity;
     using System.IO;
+    using System.Configuration;
+    using System.Web;
 
-    /// <summary>
-    /// The data context for this module.
-    /// </summary>
-    public class ModuleDbContext : DbContext
+/// <summary>
+/// The data context for this module.
+/// </summary>
+public class ModuleDbContext : DbContext
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModuleDbContext"/> class.

--- a/Module/module/Data/ModuleDbContext.cs
+++ b/Module/module/Data/ModuleDbContext.cs
@@ -3,9 +3,11 @@
 
 namespace $ext_rootnamespace$.Data
 {
+    using $ext_rootnamespace$.Data.Entities;
+    using System;
     using System.Data.Common;
     using System.Data.Entity;
-    using $ext_rootnamespace$.Data.Entities;
+    using System.IO;
 
     /// <summary>
     /// The data context for this module.
@@ -16,7 +18,7 @@ namespace $ext_rootnamespace$.Data
         /// Initializes a new instance of the <see cref="ModuleDbContext"/> class.
         /// </summary>
         public ModuleDbContext()
-            : base("name=SiteSqlServer")
+            : base(GetConnectionString())
         {
         }
 
@@ -33,5 +35,37 @@ namespace $ext_rootnamespace$.Data
         /// Gets or sets the module items.
         /// </summary>
         public DbSet<Item> Items { get; set; }
+
+        private static string GetConnectionString()
+        {
+            // For runtime
+            if (HttpContext.Current != null)
+            {
+                Console.WriteLine("HttpContext was not null");
+                return "name=SiteSqlServer";
+            }
+
+            // For CLI tools, start from the current base directory and move up until we find web.config
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string configFilePath = Path.Combine(baseDirectory, "web.config");
+            while (!File.Exists(configFilePath) && baseDirectory != null)
+            {
+                baseDirectory = Directory.GetParent(baseDirectory)?.FullName;
+                if (baseDirectory == null)
+                {
+                    throw new FileNotFoundException("web.config not found in any parent directory.");
+                }
+
+                configFilePath = Path.Combine(baseDirectory, "web.config");
+            }
+
+            // Load the configuration manually from the web.config file
+            var fileMap = new ExeConfigurationFileMap { ExeConfigFilename = configFilePath };
+            var config = ConfigurationManager.OpenMappedExeConfiguration(fileMap, ConfigurationUserLevel.None);
+            var connectionString = config.ConnectionStrings.ConnectionStrings["SiteSqlServer"];
+            return connectionString == null
+                ? throw new NullReferenceException("Connection string 'SiteSqlServer' not found.")
+                : connectionString.ConnectionString;
+        }
     }
 }

--- a/PersonaBarModule/_build/Build.cs
+++ b/PersonaBarModule/_build/Build.cs
@@ -539,28 +539,6 @@ class Build : NukeBuild
             );
     });
 
-
-    Target GenerateAppConfig => _ => _
-    .OnlyWhenDynamic(() => RootDirectory.Parent.ToString().EndsWith("DesktopModules", StringComparison.OrdinalIgnoreCase))
-    .Executes(() =>
-    {
-        var webConfigPath = RootDirectory.Parent.Parent / "web.config";
-        var webConfigDoc = new XmlDocument();
-        webConfigDoc.Load(webConfigPath);
-        var connectionString = webConfigDoc.SelectSingleNode("/configuration/connectionStrings/add[@name='SiteSqlServer']");
-
-        var appConfigPath = RootDirectory / "_build" / "App.config";
-        var appConfig = new XmlDocument();
-        var configurationNode = appConfig.AppendChild(appConfig.CreateElement("configuration"));
-        var connectionStringsNode = configurationNode.AppendChild(appConfig.CreateElement("connectionStrings"));
-        var importedNode = connectionStringsNode.OwnerDocument.ImportNode(connectionString, true);
-        connectionStringsNode.AppendChild(importedNode);
-        appConfig.Save(appConfigPath);
-
-        Serilog.Log.Information("Generated {0} from {1}", appConfigPath, webConfigPath);
-        Serilog.Log.Information("This file is local as it could contain credentials, it should not be committed to the repository.");
-    });
-
     Target SetDependencyVersions => _ => _
     .After(Compile)
     .Executes(() =>
@@ -603,7 +581,6 @@ class Build : NukeBuild
         .DependsOn(SetManifestVersions)
         .DependsOn(Compile)
         .DependsOn(SetRelativeScripts)
-        .DependsOn(GenerateAppConfig)
         .DependsOn(Test)
         .DependsOn(UpdateTokens)
         .DependsOn(CopyScripts)


### PR DESCRIPTION
This allows the data context to just discover the connection string from the environment, simplifying db migrations amongst other things.

Closes #873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed build-time generation of App.config so packaging no longer creates or writes an application config file.
  * Changed database connection handling to resolve the connection string at runtime (uses web/runtime context or searches config files) and caches the result instead of relying on a hard-coded value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->