### PR TITLE
Fixed a wrong eslint configuration

### DIFF
--- a/Module/module.web/eslint.config.ts
+++ b/Module/module.web/eslint.config.ts
@@ -28,7 +28,6 @@ export default defineConfig(
       sourceType: "module",
       parserOptions: {
         projectService: true,
-        project: 'tsconfig.json',
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/PersonaBarModule/module.web/eslint.config.ts
+++ b/PersonaBarModule/module.web/eslint.config.ts
@@ -28,7 +28,6 @@ export default defineConfig(
       sourceType: "module",
       parserOptions: {
         projectService: true,
-        project: 'tsconfig.json',
         tsconfigRootDir: import.meta.dirname,
       },
     },


### PR DESCRIPTION
projectService already locates the project and specifying it is useless and threw an error

Closes #888 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to adjust TypeScript project resolution behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->