### PR TITLE
Upgrade NSwag packages to version 14.6.3

### DIFF
--- a/Module/build/ProjectTemplate.csproj
+++ b/Module/build/ProjectTemplate.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSwag.MSBuild" Version="14.6.1" />
+    <PackageReference Include="NSwag.MSBuild" Version="14.6.3" />
 	<PackageDownload Include="docfx" Version="[2.78.3]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.10.1]" />
     <PackageDownload Include="coverlet.console" Version="[1.7.2]" />

--- a/Module/module/ProjectTemplate.csproj
+++ b/Module/module/ProjectTemplate.csproj
@@ -153,7 +153,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NSwag.Annotations">
-      <Version>14.6.1</Version>
+      <Version>14.6.3</Version>
     </PackageReference>
 	<PackageReference Include="OneOf">
 	  <Version>3.0.271</Version>

--- a/Module/module/manifest.dnn
+++ b/Module/module/manifest.dnn
@@ -37,7 +37,7 @@
             <assembly>
               <name>NSwag.Annotations.dll</name>
               <path>bin</path>
-              <version>14.6.1</version>
+              <version>14.6.3</version>
             </assembly>
 			<assembly>
 			  <name>FluentValidation.dll</name>

--- a/PersonaBarModule/_build/ProjectTemplate.csproj
+++ b/PersonaBarModule/_build/ProjectTemplate.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSwag.MSBuild" Version="14.6.1" />
+    <PackageReference Include="NSwag.MSBuild" Version="14.6.3" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.10.1]" />
     <PackageDownload Include="coverlet.console" Version="[1.7.2]" />
   </ItemGroup>

--- a/PersonaBarModule/module/manifest.dnn
+++ b/PersonaBarModule/module/manifest.dnn
@@ -28,7 +28,7 @@
             <assembly>
               <name>NSwag.Annotations.dll</name>
               <path>bin</path>
-              <version>14.6.1</version>
+              <version>14.6.3</version>
             </assembly>
 			<assembly>
 			  <name>FluentValidation.dll</name>


### PR DESCRIPTION
Updated the `NSwag.MSBuild` package in `ProjectTemplate.csproj` from version `14.6.1` to `14.6.3`. Updated the `NSwag.Annotations` package in `ProjectTemplate.csproj` from version `14.6.1` to `14.6.3`. Also updated the `NSwag.Annotations.dll` assembly version in `manifest.dnn` from `14.6.1` to `14.6.3`.

These upgrades ensure the project benefits from the latest features, bug fixes, and improvements provided in the newer version of the `NSwag` library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NSwag library dependencies to the latest patch version across multiple modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->