### PR TITLE
Update Microsoft.TestPlatform.ObjectModel to 18.0.1

### DIFF
--- a/Module/IntegrationTests/ProjectTemplate.csproj
+++ b/Module/IntegrationTests/ProjectTemplate.csproj
@@ -37,7 +37,7 @@
 		<PackageReference Include="DotNetNuke.WebApi" Version="10.1.2" />
 		<PackageReference Include="Effort.EF6" Version="2.2.17" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.0" />
+		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/Module/UnitTests/ProjectTemplate.csproj
+++ b/Module/UnitTests/ProjectTemplate.csproj
@@ -45,7 +45,7 @@
 		<PackageReference Include="DotNetNuke.WebApi" Version="10.1.2" />
 		<PackageReference Include="Effort.EF6" Version="2.2.17" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.0" />
+		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/PersonaBarModule/UnitTests/ProjectTemplate.csproj
+++ b/PersonaBarModule/UnitTests/ProjectTemplate.csproj
@@ -44,7 +44,7 @@
 		<PackageReference Include="DotNetNuke.Web" Version="10.1.2" />
 		<PackageReference Include="DotNetNuke.WebApi" Version="10.1.2" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.0" />
+		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
Updated the `Microsoft.TestPlatform.ObjectModel` package reference in `ProjectTemplate.csproj` files from version `18.0.0` to `18.0.1` to ensure the project uses the latest minor version, which may include bug fixes and improvements.

The update was applied consistently across multiple instances of the `ProjectTemplate.csproj` file. Additionally, existing `PackageReference` entries for `DotNetNuke.Core` (version `10.1.2`) and `xunit.runner.msbuild` (version `2.9.3`) remain unchanged in one instance of the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Microsoft.TestPlatform.ObjectModel dependency to version 18.0.1 across test projects to maintain compatibility and ensure optimal testing infrastructure performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->