### PR TITLE
Update NuGet.CommandLine to version 7.0.1

### DIFF
--- a/Module/build/ProjectTemplate.csproj
+++ b/Module/build/ProjectTemplate.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
 	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.3.0]" />
-	<PackageReference Include="NuGet.CommandLine" Version="6.14.0">
+	<PackageReference Include="NuGet.CommandLine" Version="7.0.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/PersonaBarModule/_build/ProjectTemplate.csproj
+++ b/PersonaBarModule/_build/ProjectTemplate.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
 	<PackageDownload Include="WebApiToOpenApiReflector" Version="[1.3.0]" />
-	<PackageReference Include="NuGet.CommandLine" Version="6.14.0">
+	<PackageReference Include="NuGet.CommandLine" Version="7.0.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updated the `NuGet.CommandLine` package reference in the `ProjectTemplate.csproj` file from version 6.14.0 to 7.0.1. This upgrade ensures the project benefits from the latest bug fixes, performance improvements, and new features provided in the updated version.