### PR TITLE
Bumped @types/node from 24.10.4 to 25.0.3

### DIFF
--- a/Module/module.web/package.json
+++ b/Module/module.web/package.json
@@ -33,7 +33,7 @@
     "@stencil/core": "^4.38.0",
     "@stencil/sass": "^3.0.2",
     "@stencil/store": "^2.0.0",
-    "@types/node": "^24.6.2",
+    "@types/node": "^25.0.3",
     "eslint-plugin-tsdoc": "^0.5.0",
     "jiti": "^2.4.2",
     "typescript": "^5.8.3",

--- a/PersonaBarModule/module.web/package.json
+++ b/PersonaBarModule/module.web/package.json
@@ -31,7 +31,7 @@
     "@stencil/eslint-plugin": "^1.1.0",
     "@stencil/sass": "^3.0.2",
     "@types/jquery": "^3.5.30",
-    "@types/node": "^24.6.2",
+    "@types/node": "^25.0.3",
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
Bumped @types/node from 24.10.4 to 25.0.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies for TypeScript type support across project modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->