### PR TITLE
Bumped ReportGenerator from 5.5.0 to 5.5.1

### DIFF
--- a/Module/build/ProjectTemplate.csproj
+++ b/Module/build/ProjectTemplate.csproj
@@ -17,7 +17,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nuke.Common" Version="10.1.0" />
-    <PackageReference Include="ReportGenerator" Version="5.5.0" />
+    <PackageReference Include="ReportGenerator" Version="5.5.1" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/PersonaBarModule/_build/ProjectTemplate.csproj
+++ b/PersonaBarModule/_build/ProjectTemplate.csproj
@@ -17,7 +17,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nuke.Common" Version="10.1.0" />
-    <PackageReference Include="ReportGenerator" Version="5.5.0" />
+    <PackageReference Include="ReportGenerator" Version="5.5.1" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Bumped ReportGenerator from 5.5.0 to 5.5.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ReportGenerator dependency to version 5.5.1 across project configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->