### PR TITLE
Bumped Microsoft.CodeAnalysis.NetAnalyzers from 10.0.100 to 10.0.101

### DIFF
--- a/Module/module/ProjectTemplate.csproj
+++ b/Module/module/ProjectTemplate.csproj
@@ -145,7 +145,7 @@
       <Version>5.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <Version>10.0.100</Version>
+      <Version>10.0.101</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/PersonaBarModule/module/ProjectTemplate.csproj
+++ b/PersonaBarModule/module/ProjectTemplate.csproj
@@ -115,7 +115,7 @@
       <Version>5.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <Version>10.0.100</Version>
+      <Version>10.0.101</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Bumped Microsoft.CodeAnalysis.NetAnalyzers from 10.0.100 to 10.0.101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated code analysis tools to the latest patch version across multiple projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->